### PR TITLE
Use of .test instead of double negation

### DIFF
--- a/src/logic/isNumber.js
+++ b/src/logic/isNumber.js
@@ -1,3 +1,3 @@
 export default function isNumber(item) {
-  return !!item.match(/[0-9]+/);
+  return /[0-9]+/.test(item);
 }


### PR DESCRIPTION
Remove the double negation with the .test function from the RegExp Object. 

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test