### PR TITLE
Bug Fix for #17 Multiple Presses of Multiplication or Division Error

### DIFF
--- a/src/logic/calculate.test.js
+++ b/src/logic/calculate.test.js
@@ -154,4 +154,20 @@ describe("calculate", function() {
   test(["2", "x", "2", "%"], {
     total: "0.04",
   });
+
+  //Test that pressing the multiplication or division sign multiple times should not affect the current computation
+  test(["2", "x", "x"], {
+    total: "2",
+    operation: "x"
+  });
+
+  test(["2", "÷", "÷"], {
+    total: "2",
+    operation: "÷"
+  });
+
+  test(["2", "÷", "x", "+", "-", "x"], {
+    total: "2",
+    operation: 'x'
+  });
 });

--- a/src/logic/operate.js
+++ b/src/logic/operate.js
@@ -2,7 +2,7 @@ import Big from "big.js";
 
 export default function operate(numberOne, numberTwo, operation) {
   const one = Big(numberOne || "0");
-  const two = Big(numberTwo || "0");
+  const two = Big(numberTwo || (operation === "÷" || operation === 'x' ? "1": "0")); //If dividing or multiplying, then 1 maintains current value in cases of null
   if (operation === "+") {
     return one.plus(two).toString();
   }


### PR DESCRIPTION
@ahfarmer I hope you will take a look at my fix for #17. It fixes multiple presses for multiplication and division by making the default value for a null number dependent on the operation. Thanks!