### PR TITLE
Fix: divide 0, condition error

### DIFF
--- a/src/logic/operate.js
+++ b/src/logic/operate.js
@@ -13,7 +13,7 @@ export default function operate(numberOne, numberTwo, operation) {
     return one.times(two).toString();
   }
   if (operation === "÷") {
-    if (two === "0") {
+    if (two.eq(0)) {
       alert("Divide by 0 error");
       return "0";
     } else {


### PR DESCRIPTION
`two.eg(0)` instead of `two === "0"`