### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "npm install && npm start"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Calculator
 
 Created with *create-react-app*. See the [full create-react-app guide](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md).
 
+[![Run on Repl.it](https://repl.it/badge/github/ahfarmer/calculator)](https://repl.it/github/ahfarmer/calculator)
+
 
 
 Try It


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@josephescamilla/calculator).