### PR TITLE
Issue #25 - Overrides leftmost zero with next non-zero number 

### DIFF
--- a/src/logic/calculate.js
+++ b/src/logic/calculate.js
@@ -28,7 +28,9 @@ export default function calculate(obj, buttonName) {
     // If there is an operation, update next
     if (obj.operation) {
       if (obj.next) {
-        return { next: obj.next + buttonName };
+        const next = obj.next === "0" ? buttonName : obj.next + buttonName;
+
+        return { next: next };
       }
       return { next: buttonName };
     }


### PR DESCRIPTION
The calculator was considering left most zero after any operation button is clicked. The problem is solved in this PR.